### PR TITLE
Docs: restructure documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,39 +17,9 @@ ILP wallet with hosted ledger and connector instances
 
 # Quick Start
 
-### Install dependencies
+_Prerequisites: Git, Node v6.9.1, `build-essentials` (or XCode command-line tools on OSX)_
 
-#### OSX
-
-Requires XCode command line tools.
-
-```sh
-$ brew tap homebrew/services
-$ brew install postgres libpqxx postgresql
-$ brew services start postgresql
-```
-
-#### Linux
-
-```sh
-$ sudo apt-get update
-$ sudo apt-get install libssl-dev python build-essential libpq-dev postgresql postgresql-contrib
-```
-
-### Set up ILP Kit
-
-First, create a postgres database.
-
-```sh
-$ sudo -u postgres createuser -s myusername # assuming your user is 'myusername'
-$ psql
-postgres=> ALTER USER myusername WITH PASSWORD 'PASSWORD'; # use a better password
-# outputs: ALTER USER
-postgres=> \q
-$ createdb ilp-kit-quickstart
-```
-
-Now clone the ILP Kit and install the dependencies.
+Clone the ILP Kit and install the dependencies.
 
 ```sh
 $ git clone https://github.com/interledgerjs/ilp-kit
@@ -76,7 +46,7 @@ In another shell, in your `ilp-kit` folder, configure your ILP Kit:
 $ npm run configure
 ```
 
-- Postgres DB URI: `postgres://myusername:PASSWORD@localhost/ilp-kit-quickstart`
+- DB URI: `sqlite://ilp-kit.db`
 - Hostname: `quickstart.localtunnel.me`
 - Ledger name: `quickstart`
 - Currency code: `USD`
@@ -86,7 +56,7 @@ $ npm run configure
 - Username: `quickstart`
 - Password: (use the randomly generated suggestion, and write it down)
 
-### Start your ILP Kit
+The setup is complete, so run:
 
 ```sh
 npm start

--- a/README.md
+++ b/README.md
@@ -17,52 +17,22 @@ ILP wallet with hosted ledger and connector instances
 
 # Quick Start
 
-_Prerequisites: Git, Node v6.9.1, `build-essentials` (or XCode command-line tools on OSX)_
-
-Clone the ILP Kit and install the dependencies.
+_Prerequisites: [Git](https://git-scm.com/downloads), [Node v6.9.1](https://nodejs.org/en/download/), and dependencies for [`node-gyp`](https://github.com/nodejs/node-gyp#installation)_
 
 ```sh
 $ git clone https://github.com/interledgerjs/ilp-kit
 $ cd ilp-kit
 $ npm install
 $ npm run build
-```
-
-You'll want to use [Localtunnel](https://localtunnel.me) to expose the ILP Kit
-to the internet. **NOTE: Because a localtunnel domain can be squatted on, do
-not use this to host a permanent ILP Kit.** If you want a permanent solution,
-follow the [permanent setup
-instructions](https://github.com/interledgerjs/ilp-kit/blob/master/docs/SETUP.md).
-
-```sh
-$ sudo npm install -g localtunnel
-$ lt --subdomain quickstart --port 3010 # use a unique subdomain
-# leave this running and restart it if it dies
-```
-
-In another shell, in your `ilp-kit` folder, configure your ILP Kit:
-
-```sh
 $ npm run configure
 ```
 
-- DB URI: `sqlite://ilp-kit.db`
-- Hostname: `quickstart.localtunnel.me`
-- Ledger name: `quickstart`
-- Currency code: `USD`
-- Country code: `US`
-- Configure Github: `n`
-- Configure Mailgun: `n`
-- Username: `quickstart`
-- Password: (use the randomly generated suggestion, and write it down)
-
-The setup is complete, so run:
+Use the default option for every question in the `configure` command,
+and you're done! You now have a configured ILP Kit. Start it with:
 
 ```sh
 npm start
 ```
-
-That's all! You now have a functioning ILP Kit.
 
 # Connect your ILP Kit
 

--- a/README.md
+++ b/README.md
@@ -15,151 +15,97 @@ ILP wallet with hosted ledger and connector instances
 [circle-image]: https://circleci.com/gh/interledgerjs/ilp-kit.svg?style=shield&circle-token=65d802e1ea641aabcc95f8d28f2c6ade577716a9
 [circle-url]: https://circleci.com/gh/interledgerjs/ilp-kit
 
-## Table of contents
+# Quick Start
 
-- [Setup](https://github.com/interledgerjs/ilp-kit/blob/master/docs/SETUP.md)
-- [Development](https://github.com/interledgerjs/ilp-kit/blob/master/docs/DEV.md)
-- [Environment variables](#environment-variables)
-- [Advanced Mode](#advanced-mode)
-- [Architecture](#architecture)
-  - [Backend (REST API)](#backend-rest-api)
-    - [API docs](#api-docs)
-    - [SPSP](#spsp)
-      - [Webfinger](#webfinger)
-  - [Client](#client)
-    - [Using Redux DevTools](#using-redux-devtools)
-    - [Theme Customization](#theme-customization)
+### Install dependencies
 
-## [Setup](https://github.com/interledgerjs/ilp-kit/blob/master/docs/SETUP.md)
+#### OSX
 
-## [Development](https://github.com/interledgerjs/ilp-kit/blob/master/docs/DEV.md)
+Requires XCode command line tools.
 
-## Environment variables
-
-Note: Most of the variables can either be set as environment variable or in a config file. The default config file is `env.list`. Environment variables take precedence over variables set in the config file.
-
-##### Required
-
-Name | Example | Description |
----- | ------- | ----------- |
-`API_HOSTNAME` | `wallet.com` | API public hostname.
-`API_PORT` | `3000` | API private port (used as both public and private port if `API_PUBLIC_PORT` is not specified).
-`DB_URI` | `postgres://localhost/wallet` | URI for connecting to a database.
-`API_LEDGER_ADMIN_USER` | `admin` | Ledger admin username.
-`API_LEDGER_ADMIN_PASS` | `pass` | Ledger admin pass.
-`CLIENT_HOST` | `wallet.com` | Publicly visible hostname.
-`CLIENT_PORT` | `4000` | Client port.
-`LEDGER_ILP_PREFIX` | `wallet.` | This is required if the `API_LEDGER_URI` is not specified
-
-##### Optional
-
-Name | Example | Description |
----- | ------- | ----------- |
-`API_CONFIG_FILE` | custom-env.list | Specifies the path from which to load the config file. **Needs to be defined as environment variable**.
-`API_PRIVATE_HOSTNAME` | `localhost` | Private API hostname.
-`API_PUBLIC_PORT` |  | Api public port.
-`API_SECRET` | `qO2UX+fdl+tg0a1bYt` | Api secret. Used to generate the session, oauth and condition secrets.
-`API_RELOAD` | `true` | Turn on/off the reload endpoint.
-`API_LEDGER_URI` | `http://wallet.com:2000` | Ledger URI: requests go to this uri (a ledger instance will be started by the wallet if this is not specified).
-`API_LEDGER_PUBLIC_URI` | `http://wallet.com/ledger` | Ledger public URI (used in account URIs). Specified if different from the `API_LEDGER_URI`.
-`API_TRACK_GA` | `UA-XXXXX-X` | Google Analytics Tracking ID.
-`API_TRACK_MIXPANEL` | | Mixpanel Tracking ID.
-`API_GITHUB_CLIENT_ID` | | Github application client id (used for github oauth).
-`API_GITHUB_CLIENT_SECRET` | | Github application client secret (used for github oauth).
-`API_MAILGUN_API_KEY` | | Mailgun api key (for sending emails).
-`API_MAILGUN_DOMAIN` | `wallet.com` | One of the domains attached to the Mailgun account.
-`API_ANTIFRAUD_SERVICE_URL` | `antifraud.wallet.com` | Anti fraud service url. This will enable an additional step in registration that asks for personal details
-`API_ANTIFRAUD_MAX_RISK` | `20` | Maximum tolerable risk level for the registration
-`API_EMAIL_SENDER_NAME` | `info` | Email sender name
-`API_EMAIL_SENDER_ADDRESS` | `contact@wallet.com` | Email sender address
-`API_REGISTRATION` | `true` | Enable/Disable registration
-`WALLET_FORCE_HTTPS` | `true` | Force all connections to use HTTPS.
-`WALLET_TRUST_XFP_HEADER` | `true` | Trust the `X-Forwarded-Proto` header.
-`CONNECTOR_ENABLE` | `false` | Run a connector instance
-`CLIENT_PUBLIC_PORT` | `80` | Client public port (if different from `CLIENT_PORT`)
-`CLIENT_TITLE` | `ILP Kit` | Browser title and logo
-
-##### Default five-bells-ledger environment variables 
-(used if the `API_LEDGER_URI` is not specified). You can read more about these variables in the [five-bells-ledger readme](https://github.com/interledgerjs/five-bells-ledger#step-3-run-it).
-
-Name | Default |
----- | ------- |
-`LEDGER_DB_URI` | `DB_URI`
-`LEDGER_ADMIN_USER` | `API_LEDGER_ADMIN_USER`
-`LEDGER_ADMIN_PASS` | `API_LEDGER_ADMIN_PASS`
-`LEDGER_HOSTNAME` | `API_HOSTNAME`
-`LEDGER_PORT` | `API_PORT + 1`
-`LEDGER_PUBLIC_PORT` | `CLIENT_PORT`
-`LEDGER_PUBLIC_PATH` | `ledger`
-`LEDGER_CURRENCY_CODE` | `USD`
-`LEDGER_CURRENCY_SYMBOL` | `$`
-
-## Advanced Mode
-ILP kit UI comes with an "advanced mode" for developers and advanced users. You can activate it with a hot-key: `option+d` on Mac or `alt+d` on Windows. 
-
-## Architecture
-ILP kit consists of a [Node.js](https://github.com/nodejs/node) (developed on v6.9.1) backend (REST API) and a client built using [React](https://github.com/facebook/react).
-
-### Backend (REST API)
-The backend is responsible for communicating with the ILP ledger, creating accounts, sending payments and keeping the payment history.
-
-#### API docs
-[http://interledger.org/ilp-kit/apidoc](http://interledger.org/ilp-kit/apidoc/)
-
-#### SPSP
-
-The wallet implements [SPSP](https://github.com/interledger/rfcs/blob/master/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md) for initiating and receiving payments.
-
-##### Webfinger
-Webfinger is used to lookup account/user identifiers.
-
-Example request 
-```bash
-curl -X GET
-https://wallet.example/.well-known/webfinger?resource=acct:alice@wallet.example
+```sh
+$ brew tap homebrew/services
+$ brew install postgres libpqxx postgresql
+$ brew services start postgresql
 ```
 
-Example response 
-```bash
-HTTP/1.1 200 OK
-{
-  "subject": "acct:alice@red.ilpdemo.org",
-  "links": [
-    {
-      "rel": "https://interledger.org/rel/ledgerUri",
-      "href": "https://red.ilpdemo.org/ledger"
-    },
-    {
-      "rel": "https://interledger.org/rel/socketIOUri",
-      "href": "https://red.ilpdemo.org/api/socket.io"
-    },
-    {
-      "rel": "https://interledger.org/rel/ledgerAccount",
-      "href": "https://red.ilpdemo.org/ledger/accounts/alice"
-    },
-    {
-      "rel": "https://interledger.org/rel/sender/payment",
-      "href": "https://red.ilpdemo.org/api/payments"
-    },
-    {
-      "rel": "https://interledger.org/rel/sender/pathfind",
-      "href": "https://red.ilpdemo.org/api/payments/findPath"
-    },
-    {
-      "rel": "https://interledger.org/rel/receiver",
-      "href": "https://red.ilpdemo.org/api/receivers/alice"
-    }
-  ]
-}
+#### Linux
+
+```sh
+$ sudo apt-get update
+$ sudo apt-get install libssl-dev python build-essential libpq-dev postgresql postgresql-contrib
 ```
 
-### Client
-The client is a web app built on [React](https://github.com/facebook/react) that implements user signup/signin, sending payments and payment history.
+### Set up ILP Kit
 
-Client state management is handled by [Redux](https://github.com/reactjs/redux).
+First, create a postgres database.
 
-#### Theme Customization
+```sh
+$ sudo -u postgres createuser -s myusername # assuming your user is 'myusername'
+$ psql
+postgres=> ALTER USER myusername WITH PASSWORD 'PASSWORD'; # use a better password
+# outputs: ALTER USER
+postgres=> \q
+$ createdb ilp-kit-quickstart
+```
 
-`npm install` generates a `src/theme/variables.scss` which contains the theme colors. You can manually edit it.
+Now clone the ILP Kit and install the dependencies.
 
-Database has two tables: Users and Payments.
+```sh
+$ git clone https://github.com/interledgerjs/ilp-kit
+$ cd ilp-kit
+$ npm install
+$ npm run build
+```
+
+You'll want to use [Localtunnel](https://localtunnel.me) to expose the ILP Kit
+to the internet. **NOTE: Because a localtunnel domain can be squatted on, do
+not use this to host a permanent ILP Kit.** If you want a permanent solution,
+follow the [permanent setup
+instructions](https://github.com/interledgerjs/ilp-kit/blob/master/docs/SETUP.md).
+
+```sh
+$ sudo npm install -g localtunnel
+$ lt --subdomain quickstart --port 3010 # use a unique subdomain
+# leave this running and restart it if it dies
+```
+
+In another shell, in your `ilp-kit` folder, configure your ILP Kit:
+
+```sh
+$ npm run configure
+```
+
+- Postgres DB URI: `postgres://myusername:PASSWORD@localhost/ilp-kit-quickstart`
+- Hostname: `quickstart.localtunnel.me`
+- Ledger name: `quickstart`
+- Currency code: `USD`
+- Country code: `US`
+- Configure Github: `n`
+- Configure Mailgun: `n`
+- Username: `quickstart`
+- Password: (use the randomly generated suggestion, and write it down)
+
+### Start your ILP Kit
+
+```sh
+npm start
+```
+
+That's all! You now have a functioning ILP Kit.
+
+# Connect your ILP Kit
+
+Follow [these
+instructions](https://github.com/interledgerjs/ilp-kit/blob/master/docs/SETUP.md#connecting-your-ledger)
+in order to peer with another ILP Kit, and send some inter-ledger payments.
+
+If you're looking for someone to peer with, reach out to one of the [known ILP
+nodes](https://github.com/interledgerjs/ilp-kit/wiki/Known-ILP-Nodes) or the
+[Interledger mailing list](https://www.w3.org/community/interledger/).
+
+# Documentation
+
+- [Setting up a permament ILP Kit](https://github.com/interledgerjs/ilp-kit/blob/master/docs/SETUP.md)
+- [Environment variable documentation](https://github.com/interledgerjs/ilp-kit/blob/master/docs/ENV.md)
+- [Development instructions](https://github.com/interledgerjs/ilp-kit/blob/master/docs/DEV.md)

--- a/bin/localTunnel.js
+++ b/bin/localTunnel.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+'use strict'
+
+const localtunnel = require('localtunnel')
+const debug = require('debug')('localtunnel')
+require('./normalizeEnv')
+
+const reconnector = (port, host) => {
+  return setTimeout.bind(null, connect.bind(null, port, host), 2000)
+}
+
+const connect = (port, host) => {
+  const subdomain = host.replace(/\.localtunnel\.me$/, '')
+  const reconnect = reconnector(port, host)
+  try {
+    const tunnel = localtunnel(port, { subdomain }, (err, tunnel) => {
+      if (err) {
+        reconnect()
+        return
+      }
+
+      debug('connected localtunnel to', tunnel.url)
+      tunnel.on('close', reconnect)
+      tunnel.on('error', reconnect)
+    })
+  } catch (err) {
+    debug('Error occurred:', err.message, 'Restarting localtunnel.')
+    reconnect()
+  }  
+}
+
+// if the hostname is a subdomain of "localtunnel.me"
+if (process.env.CLIENT_HOST.match(/\.localtunnel\.me$/)) {
+  console.log('creating localtunnel to ', process.env.CLIENT_HOST)
+  connect(process.env.CLIENT_PORT, process.env.CLIENT_HOST)
+} else {
+  process.exit(0)
+}

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,58 @@
+# Environment variables
+
+##### Required
+
+Name | Example | Description |
+---- | ------- | ----------- |
+`API_HOSTNAME` | `wallet.com` | API public hostname.
+`API_PORT` | `3000` | API private port (used as both public and private port if `API_PUBLIC_PORT` is not specified).
+`API_DB_URI` | `postgres://localhost/wallet` | URI for connecting to a database.
+`API_LEDGER_ADMIN_USER` | `admin` | Ledger admin username.
+`API_LEDGER_ADMIN_PASS` | `pass` | Ledger admin pass.
+`CLIENT_HOST` | `wallet.com` | Publicly visible hostname.
+`CLIENT_PORT` | `4000` | Client port.
+`LEDGER_ILP_PREFIX` | `wallet.` | This is required if the `API_LEDGER_URI` is not specified
+
+##### Optional
+
+Name | Example | Description |
+---- | ------- | ----------- |
+`API_PUBLIC_HTTPS` |  | Whether or not the publicly visible instance of ILP kit is using HTTPS.
+`API_PRIVATE_HOSTNAME` | `localhost` | Private API hostname.
+`API_PUBLIC_PORT` |  | Api public port.
+`API_SECRET` | `qO2UX+fdl+tg0a1bYt` | Api secret. Used to generate the session, oauth and condition secrets.
+`API_RELOAD` | `true` | Turn on/off the reload endpoint.
+`API_LEDGER_URI` | `http://wallet.com:2000` | Ledger URI: requests go to this uri (a ledger instance will be started by the wallet if this is not specified).
+`API_LEDGER_PUBLIC_URI` | `http://wallet.com/ledger` | Ledger public URI (used in account URIs). Specified if different from the `API_LEDGER_URI`.
+`API_TRACK_GA` | `UA-XXXXX-X` | Google Analytics Tracking ID.
+`API_TRACK_MIXPANEL` | | Mixpanel Tracking ID.
+`API_GITHUB_CLIENT_ID` | | Github application client id (used for github oauth).
+`API_GITHUB_CLIENT_SECRET` | | Github application client secret (used for github oauth).
+`API_MAILGUN_API_KEY` | | Mailgun api key (for sending emails).
+`API_MAILGUN_DOMAIN` | `wallet.com` | One of the domains attached to the Mailgun account.
+`API_ANTIFRAUD_SERVICE_URL` | `antifraud.wallet.com` | Anti fraud service url. This will enable an additional step in registration that asks for personal details
+`API_ANTIFRAUD_MAX_RISK` | `20` | Maximum tolerable risk level for the registration
+`API_EMAIL_SENDER_NAME` | `info` | Email sender name
+`API_EMAIL_SENDER_ADDRESS` | `contact@wallet.com` | Email sender address
+`API_REGISTRATION` | `true` | Enable/Disable registration
+`WALLET_FORCE_HTTPS` | `true` | Force all connections to use HTTPS.
+`WALLET_TRUST_XFP_HEADER` | `true` | Trust the `X-Forwarded-Proto` header.
+`CONNECTOR_ENABLE` | `false` | Run a connector instance
+`CLIENT_PUBLIC_PORT` | `80` | Client public port (if different from `CLIENT_PORT`)
+`CLIENT_TITLE` | `ILP Kit` | Browser title and logo
+
+##### Default five-bells-ledger environment variables 
+(used if the `API_LEDGER_URI` is not specified). You can read more about these variables in the [five-bells-ledger readme](https://github.com/interledgerjs/five-bells-ledger#step-3-run-it).
+
+Name | Default |
+---- | ------- |
+`LEDGER_DB_URI` | `API_DB_URI`
+`LEDGER_ADMIN_USER` | `API_LEDGER_ADMIN_USER`
+`LEDGER_ADMIN_PASS` | `API_LEDGER_ADMIN_PASS`
+`LEDGER_HOSTNAME` | `API_HOSTNAME`
+`LEDGER_PORT` | `API_PORT + 1`
+`LEDGER_PUBLIC_PORT` | `CLIENT_PORT`
+`LEDGER_PUBLIC_PATH` | `ledger`
+`LEDGER_CURRENCY_CODE` | `USD`
+`LEDGER_CURRENCY_SYMBOL` | `$`
+`LEDGER_PUBLIC_HTTPS` | `API_PUBLIC_HTTPS`

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,9 +1,10 @@
 > Guide to setting up your very own ILP Kit.
 > Estimated time: a couple of hours.
 
-> **NOTE**: These instructions use DigitalOcean's Node 6.9.1 image on Ubuntu in
-> order to be as simple as possible. You can run ILP Kit on any other OS and
-> hosting provider, but there might be a couple additional steps.
+> **NOTE**: These instructions support either a local machine (for testing
+> only) or DigitalOcean's Node 6.9.1 image on Ubuntu. This is in order to be as
+> simple as possible. You can run ILP Kit on any other OS and hosting provider,
+> but there might be a couple additional steps.
 
 > _Don't hesitate to open issues or ask for help._
 
@@ -14,6 +15,7 @@
   - [Postgresql setup](#postgresql-setup)
   - [ILP Kit setup](#ilp-kit-setup)
 - [Domain Setup](#domain-setup)
+  - [Localtunnel setup](#localtunnel-setup)
   - [Subdomain setup](#subdomain-setup)
   - [Set up SSL](#set-up-ssl)
   - [Set up proxy for ILP Kit](#set-up-proxy-for-ilp-kit)
@@ -29,6 +31,11 @@
   - [systemd setup](#systemd-setup)
 
 # ILP Kit installation
+
+If you want to set up an ILP Kit (for testing) without buying a remote server,
+just skip this section and go to [Server Setup](#server-setup). Use the
+[Localtunnel setup](#localtunnel-setup) instructions to expose your ILP Kit to
+the internet.
 
 ## Get a server instance
 
@@ -121,6 +128,56 @@ $ npm install
 ```
 
 # Domain setup
+
+## Localtunnel setup
+
+Don't have your own domain? That's no problem. You can follow this section and skip the rest of the
+domain setup. If you want to use your own domain (recommended for any permanent ILP Kit instance), then
+skip to [Subdomain setup](#subdomain-setup) and keep reading.
+
+**NOTE: Localtunnel is for TESTING PURPOSES ONLY.** (see below for the security risks)
+
+### What is Localtunnel?
+
+Localtunnel is a service that lets you forward a local port to a subdomain on `localtunnel.me`. You can
+request a specific subdomain (eg. `niles.localtunnel.me`), but **be careful**. If the subdomain is already
+taken, your localtunnel will fail. Furthermore, if your localtunnel closes and someone else starts a tunnel
+on the same subdomain, they can intercept traffic to that domain. Therefore, Localtunnel is suitable for
+a temporary ILP Kit instance, but **is NOT SECURE for a permanent ILP Kit**.
+
+### Start a Localtunnel
+
+```
+$ sudo npm install -g localtunnel
+```
+
+This will install Localtunnel on your system, accessible through the `lt` command. If I wanted to forward
+my ILP Kit to `niles.localtunnel.me`, I would run:
+
+```
+$ lt --subdomain niles --port 3010
+# outputs: your url is: https://niles.localtunnel.me
+```
+
+Sometimes this process will crash. Just restart it with the same arguments, and it should be fine. To
+do this automatically, you can wrap the command in a while loop:
+
+```
+$ while [ 1 ]; do lt --subdomain niles --port 3010; done
+```
+
+### Use your Localtunnel
+
+That's all there is to it! In future steps, treat everything as though your
+domain is `YOURSUBDOMAIN.localtunnel.me`. This domain is reachable over `https`.
+
+You don't need to do any SSL setup or nginx proxying. Just make sure your
+subdomain is unique enough that it won't collide with anyone else's. **This
+domain can be trivially squatted on** every time you restart `lt`, so be
+careful what you use it for.
+
+You can skip ahead to [ILP Kit configuration](#ilp-kit-configuration) now, and
+follow the guide from there.
 
 ## Subdomain setup
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,10 +1,9 @@
 > Guide to setting up your very own ILP Kit.
 > Estimated time: a couple of hours.
 
-> **NOTE**: These instructions support either a local machine (for testing
-> only) or DigitalOcean's Node 6.9.1 image on Ubuntu. This is in order to be as
-> simple as possible. You can run ILP Kit on any other OS and hosting provider,
-> but there might be a couple additional steps.
+> **NOTE**: These instructions use DigitalOcean's Node 6.9.1 image on Ubuntu in
+> order to be as simple as possible. You can run ILP Kit on any other OS and
+> hosting provider, but there might be a couple additional steps.
 
 > _Don't hesitate to open issues or ask for help._
 
@@ -15,7 +14,6 @@
   - [Postgresql setup](#postgresql-setup)
   - [ILP Kit setup](#ilp-kit-setup)
 - [Domain Setup](#domain-setup)
-  - [Localtunnel setup](#localtunnel-setup)
   - [Subdomain setup](#subdomain-setup)
   - [Set up SSL](#set-up-ssl)
   - [Set up proxy for ILP Kit](#set-up-proxy-for-ilp-kit)
@@ -31,11 +29,6 @@
   - [systemd setup](#systemd-setup)
 
 # ILP Kit installation
-
-If you want to set up an ILP Kit (for testing) without buying a remote server,
-just skip this section and go to [Server Setup](#server-setup). Use the
-[Localtunnel setup](#localtunnel-setup) instructions to expose your ILP Kit to
-the internet.
 
 ## Get a server instance
 
@@ -128,56 +121,6 @@ $ npm install
 ```
 
 # Domain setup
-
-## Localtunnel setup
-
-Don't have your own domain? That's no problem. You can follow this section and skip the rest of the
-domain setup. If you want to use your own domain (recommended for any permanent ILP Kit instance), then
-skip to [Subdomain setup](#subdomain-setup) and keep reading.
-
-**NOTE: Localtunnel is for TESTING PURPOSES ONLY.** (see below for the security risks)
-
-### What is Localtunnel?
-
-Localtunnel is a service that lets you forward a local port to a subdomain on `localtunnel.me`. You can
-request a specific subdomain (eg. `niles.localtunnel.me`), but **be careful**. If the subdomain is already
-taken, your localtunnel will fail. Furthermore, if your localtunnel closes and someone else starts a tunnel
-on the same subdomain, they can intercept traffic to that domain. Therefore, Localtunnel is suitable for
-a temporary ILP Kit instance, but **is NOT SECURE for a permanent ILP Kit**.
-
-### Start a Localtunnel
-
-```
-$ sudo npm install -g localtunnel
-```
-
-This will install Localtunnel on your system, accessible through the `lt` command. If I wanted to forward
-my ILP Kit to `niles.localtunnel.me`, I would run:
-
-```
-$ lt --subdomain niles --port 3010
-# outputs: your url is: https://niles.localtunnel.me
-```
-
-Sometimes this process will crash. Just restart it with the same arguments, and it should be fine. To
-do this automatically, you can wrap the command in a while loop:
-
-```
-$ while [ 1 ]; do lt --subdomain niles --port 3010; done
-```
-
-### Use your Localtunnel
-
-That's all there is to it! In future steps, treat everything as though your
-domain is `YOURSUBDOMAIN.localtunnel.me`. This domain is reachable over `https`.
-
-You don't need to do any SSL setup or nginx proxying. Just make sure your
-subdomain is unique enough that it won't collide with anyone else's. **This
-domain can be trivially squatted on** every time you restart `lt`, so be
-careful what you use it for.
-
-You can skip ahead to [ILP Kit configuration](#ilp-kit-configuration) now, and
-follow the guide from there.
 
 ## Subdomain setup
 

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "finance"
   ],
   "scripts": {
-    "start": "DEBUG_COLORS=1 concurrently -p \"[{name}]\" -n \"ledger,api,wallet\" -c \"red,blue,cyan\" \"npm run start-prod-ledger\" \"npm run start-prod-api\" \"npm run start-prod\"",
+    "start": "DEBUG_COLORS=1 concurrently -p \"[{name}]\" -n \"ledger,api,wallet,localtunnel\" -c \"red,magenta,blue,cyan,green\" \"npm run start-prod-ledger\" \"npm run start-prod-api\" \"npm run start-prod\" \"npm run start-localtunnel\"",
     "start-prod": "better-npm-run start-prod",
     "start-prod-api": "better-npm-run start-prod-api",
     "start-prod-ledger": "better-npm-run start-prod-ledger",
+    "start-prod-connector": "better-npm-run start-prod-connector",
+    "start-localtunnel": "better-npm-run start-localtunnel",
     "build": "touch src/theme/variables-custom.scss ; better-npm-run build",
     "build-dlls": "touch src/theme/variables-custom.scss ; node ./bin/dlls.js",
     "postinstall": "npm rebuild node-sass; npm run build",
@@ -58,6 +60,18 @@
     },
     "start-prod-ledger": {
       "command": "node ./bin/ledger.js",
+      "env": {
+        "NODE_ENV": "production"
+      }
+    },
+    "start-prod-connector": {
+      "command": "node ./bin/connector.js",
+      "env": {
+        "NODE_ENV": "production"
+      }
+    },
+    "start-localtunnel": {
+      "command": "node ./bin/localTunnel.js",
       "env": {
         "NODE_ENV": "production"
       }
@@ -167,6 +181,7 @@
     "koa.io": "0.0.3",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
+    "localtunnel": "^1.8.2",
     "lodash": "^4.16.4",
     "mag": "^0.9.1",
     "mag-hub": "^0.1.1",


### PR DESCRIPTION
As per https://github.com/interledgerjs/ilp-kit/issues/107 . This version of the setup is **not secure** for a permanent ILP Kit instance, due to possible squatting issues. However, it's fine for someone who just wants to try out ILP Kit without doing all that SSL and nginx setup.