### PR TITLE
Feat: check ILP_KIT_CLI_VERSION in env.list

### DIFF
--- a/bin/normalizeEnv.js
+++ b/bin/normalizeEnv.js
@@ -37,6 +37,24 @@ try {
   }
 }
 
+// make sure versioning matches between file and this kit
+const ILP_KIT_CLI_SUPPORTED_VERSION = '10.1.0'
+
+const supportedVersion = ILP_KIT_CLI_SUPPORTED_VERSION.split('.')
+const version = (envVars.ILP_KIT_CLI_VERSION || '0.0.0').split('.')
+
+for (let i = 0; i < version.length; ++i) {
+  const v = +version[i], sv = +supportedVersion[i]
+  if (v > sv) {
+    break
+  } else if (v < sv) {
+    console.log('`env.list` version (' + envVars.ILP_KIT_CLI_VERSION
+      + ') is older than supported version (' + ILP_KIT_CLI_SUPPORTED_VERSION
+      + '). Back up your env.list and run `npm run configure` to update.')
+    process.exit()
+  }
+}
+
 // backwards compatibility
 if (!envVars.DB_URI) {
   envVars.DB_URI = envVars.API_DB_URI


### PR DESCRIPTION
https://github.com/interledgerjs/ilp-kit-cli/pull/26 puts the variable `ILP_KIT_CLI_VERSION` into env.list. When ILP Kit CLI is updated or patched, the ILP Kit should be changed so that the `ILP_KIT_SUPPORTED_VERSION` variable in `bin/normalizeEnv` doesn't support anything older.