### PR TITLE
Fix: expect ilp-kit-cli version to follow semver for env.list format

### DIFF
--- a/bin/normalizeEnv.js
+++ b/bin/normalizeEnv.js
@@ -38,21 +38,16 @@ try {
 }
 
 // make sure versioning matches between file and this kit
-const ILP_KIT_CLI_SUPPORTED_VERSION = '10.1.0'
+const version = envVars.ILP_KIT_CLI_VERSION || '0.0.0'
+const supportedVersion = require('../package.json')
+  .dependencies['ilp-kit-cli']
+  .replace(/^[\^\~]/, '')
 
-const supportedVersion = ILP_KIT_CLI_SUPPORTED_VERSION.split('.')
-const version = (envVars.ILP_KIT_CLI_VERSION || '0.0.0').split('.')
-
-for (let i = 0; i < version.length; ++i) {
-  const v = +version[i], sv = +supportedVersion[i]
-  if (v > sv) {
-    break
-  } else if (v < sv) {
-    console.log('`env.list` version (' + envVars.ILP_KIT_CLI_VERSION
-      + ') is older than supported version (' + ILP_KIT_CLI_SUPPORTED_VERSION
-      + '). Back up your env.list and run `npm run configure` to update.')
-    process.exit()
-  }
+if (+supportedVersion.split('.')[0] !== +version.split('.')[0]) {
+  console.log('`env.list` version (' + version
+    + ') is older than supported version (' + supportedVersion
+    + '). Back up your env.list and run `npm run configure` to update.')
+  process.exit()
 }
 
 // backwards compatibility


### PR DESCRIPTION
From now on, the `ilp-kit-cli`'s semantic version will follow the `env.list` format. An update to the `ilp-kit-cli` will be a major version iff it breaks the `env.list` format.