### PR TITLE
feat: add peer rpc handler

### DIFF
--- a/api/src/controllers/peers.js
+++ b/api/src/controllers/peers.js
@@ -102,12 +102,14 @@ function PeersControllerFactory(auth, config, Peer, connector) {
     }
 
     static * rpc() {
+      const prefix = this.query.prefix
       const method = this.query.method
       const params = this.body
 
-      yield connector.receive(method, params)
+      if (!prefix) throw new InvalidBodyError('Prefix is not supplied')
+      if (!method) throw new InvalidBodyError('Method is not supplied')
 
-      this.status = 200
+      this.body = yield connector.rpc(prefix, method, params)
     }
   }
 }

--- a/api/src/controllers/peers.js
+++ b/api/src/controllers/peers.js
@@ -19,6 +19,8 @@ function PeersControllerFactory(auth, config, Peer, connector) {
       router.post('/peers', auth.checkAuth, this.checkAdmin, this.postResource)
       router.put('/peers/:id', auth.checkAuth, this.checkAdmin, this.putResource)
       router.delete('/peers/:id', auth.checkAuth, this.checkAdmin, this.deleteResource)
+
+      router.post('/peers/rpc', this.rpc)
     }
 
     // TODO move to auth
@@ -54,7 +56,6 @@ function PeersControllerFactory(auth, config, Peer, connector) {
       peer.hostname = this.body.hostname
       peer.limit = this.body.limit
       peer.currency = this.body.currency
-      peer.broker = this.body.broker
 
       const dbPeer = yield peer.save()
 
@@ -98,6 +99,15 @@ function PeersControllerFactory(auth, config, Peer, connector) {
       yield peer.destroy()
 
       this.body = this.params
+    }
+
+    static * rpc() {
+      const method = this.query.method
+      const params = this.body
+
+      yield connector.receive(method, params)
+
+      this.status = 200
     }
   }
 }

--- a/api/src/controllers/webfinger.js
+++ b/api/src/controllers/webfinger.js
@@ -139,6 +139,10 @@ function WebfingerControllerFactory(log, config, ledger) {
           {
             'rel': 'https://interledger.org/rel/ledgerUri',
             'href': config.data.getIn(['ledger', 'public_uri'])
+          },
+          {
+            'rel': 'https://interledger.org/rel/peersRpcUri',
+            'href': config.data.getIn(['server', 'base_uri']) + '/peers/rpc'
           }
         ]
       }

--- a/api/src/lib/connector.js
+++ b/api/src/lib/connector.js
@@ -180,7 +180,6 @@ module.exports = class Conncetor {
   }
 
   * rpc(prefix, method, params) {
-    console.log('connector:183', prefix, method, params)
     const plugin = connector.getPlugin(prefix)
 
     return plugin.receive(method, params)

--- a/api/src/lib/connector.js
+++ b/api/src/lib/connector.js
@@ -84,68 +84,42 @@ module.exports = class Conncetor {
     if (!hostInfo) return
 
     const publicKey = hostInfo.publicKey
+    const peersRpcUri = hostInfo.peersRpcUri
+
     const token = getToken(this.config.getIn(['connector', 'ed25519_secret_key']), publicKey)
 
     this.peers[peer.id] = {
       publicKey,
+      peersRpcUri,
       ledgerName: 'peer.' + token.substring(0, 5) + '.' + peer.currency.toLowerCase() + '.',
       online: peerInfo ? peerInfo.online : false
     }
 
-    return this.peers[peer.id]
-  }
-
-  * connectPeer(peer) {
-    if (!this.peers[peer.id]) {
-      this.peers[peer.id] = {
-        online: false
-      }
-    }
-
-    // Skip if already connected
-    if (this.peers[peer.id].online) return
-
-    // Get host info
-    const hostInfo = yield this.getPeerInfo(peer)
-
-    // Couldn't get the host info (service might not be responding)
-    if (!hostInfo.publicKey) return
-
-    let promise
-
-    try {
-      promise = connector.addPlugin(hostInfo.ledgerName, {
+    return connector.addPlugin(ledgerName, {
+      currency: peer.currency,
+      plugin: 'ilp-plugin-virtual',
+      store: true,
+      options: {
+        name: peer.hostname,
+        secret: secret,
+        peerPublicKey: publicKey,
+        prefix: ledgerName,
+        rpcUri: peersRpcUri,
+        maxBalance: '' + peer.limit,
         currency: peer.currency,
-        plugin: 'ilp-plugin-virtual',
-        store: true,
-        options: {
-          name: peer.hostname,
-          secret: this.config.getIn(['connector', 'ed25519_secret_key']),
-          peerPublicKey: hostInfo.publicKey,
-          prefix: hostInfo.ledgerName,
-          broker: peer.broker,
-          maxBalance: '' + peer.limit,
-          currency: peer.currency,
-          info: {
-            currencyCode: peer.currency,
-            currencySymbol: currencies[peer.currency] || peer.currency,
-            precision: 10,
-            scale: 10,
-            connectors: [{
-              id: hostInfo.publicKey,
-              name: hostInfo.publicKey,
-              connector: hostInfo.ledgerName + hostInfo.publicKey
-            }]
-          }
+        info: {
+          currencyCode: peer.currency,
+          currencySymbol: currencies[peer.currency] || peer.currency,
+          precision: 10,
+          scale: 10,
+          connectors: [{
+            id: publicKey,
+            name: publicKey,
+            connector: ledgerName + publicKey
+          }]
         }
-      })
-
-      this.peers[peer.id].online = true
-    } catch (e) {
-      throw e
-    }
-
-    return promise
+      }
+    })
   }
 
   * removePeer(peer) {

--- a/api/src/lib/utils.js
+++ b/api/src/lib/utils.js
@@ -161,7 +161,8 @@ module.exports = class Utils {
     if (!response) return
 
     return {
-      publicKey: response.properties['https://interledger.org/rel/publicKey']
+      publicKey: response.properties['https://interledger.org/rel/publicKey'],
+      peersRpcUri: _.filter(response.links, {rel: 'https://interledger.org/rel/peersRpcUri'})[0].href,
     }
   }
 }

--- a/api/src/migrations/20170110-peers.js
+++ b/api/src/migrations/20170110-peers.js
@@ -1,0 +1,10 @@
+const Sequelize = require('sequelize')
+
+module.exports = {
+  up: (sequelize) => {
+    return sequelize.queryInterface.removeColumn('Peers', 'broker')
+  },
+  down: (sequelize) => {
+    return sequelize.queryInterface.addColumn('Peers', 'broker', Sequelize.STRING)
+  }
+}

--- a/api/src/models/peer.js
+++ b/api/src/models/peer.js
@@ -44,8 +44,7 @@ function PeerFactory(sequelize, validator) {
     },
     hostname: Sequelize.STRING,
     limit: Sequelize.FLOAT,
-    currency: Sequelize.STRING,
-    broker: Sequelize.STRING
+    currency: Sequelize.STRING
   })
 
   return Peer

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "ilp-connector": "^12.11.0",
     "ilp-kit-cli": "^10.0.1",
     "ilp-plugin-bells": "^9.1.0",
-    "ilp-plugin-virtual": "^10.0.2",
+    "ilp-plugin-virtual": "interledgerjs/ilp-plugin-virtual#6de70fb72813b0304bf5ab650e68e382e26a820f",
     "istanbul": "^0.4.5",
     "jimp": "^0.2.27",
     "json-loader": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "ilp-connector": "^12.11.0",
     "ilp-kit-cli": "^10.0.1",
     "ilp-plugin-bells": "^9.1.0",
-    "ilp-plugin-virtual": "interledgerjs/ilp-plugin-virtual#6de70fb72813b0304bf5ab650e68e382e26a820f",
+    "ilp-plugin-virtual": "^11.0.0",
     "istanbul": "^0.4.5",
     "jimp": "^0.2.27",
     "json-loader": "^0.5.4",

--- a/src/containers/PeerAddForm/PeerAddForm.js
+++ b/src/containers/PeerAddForm/PeerAddForm.js
@@ -18,7 +18,7 @@ import Input from 'components/Input/Input'
 
 @reduxForm({
   form: 'peerAdd',
-  fields: ['hostname', 'limit', 'currency', 'broker'],
+  fields: ['hostname', 'limit', 'currency'],
   validate: peerValidation
 }, null, { add })
 @successable()
@@ -55,7 +55,7 @@ export default class PeerAddForm extends Component {
   }
 
   render() {
-    const { invalid, handleSubmit, submitting, success, fail, fields: { hostname, limit, currency, broker } } = this.props
+    const { invalid, handleSubmit, submitting, success, fail, fields: { hostname, limit, currency } } = this.props
 
     return (
       <div>
@@ -74,7 +74,6 @@ export default class PeerAddForm extends Component {
             <Input object={hostname} label="Hostname" size="lg" focus />
             <Input object={limit} label="Limit" size="lg" />
             <Input object={currency} label="Currency" size="lg" />
-            <Input object={broker} label="Broker" size="lg" />
           </div>
 
           <div className="row">


### PR DESCRIPTION
@sharafian here's the proposed rpc handler.

`plugin-virtual` makes a `POST` request to `options.RPCUri` (https://example.com/api/peers/rpc) adding a `method` query param and the json body.

```
POST https://example.com/api/peers/rpc?method=send_transfer

{
  "id": "3a2a1d9e-8640-4d2d-b06c-84f2cd613204",
  "ledger": "us.usd.interledger.",
  "account": "us.usd.interledger.other",
  "amount": "5.0",
  "data": {
    "field": "some stuff"
  },
  "executionCondition": "8ZdpKBDUV-KX_OnFZTsCWB_5mlCFI3DynX5f5H2dN-Y",
  "expiresAt": "2016-10-25T08:41:59.795Z"
}
```