### PR TITLE
Fix: better errors on plugin RPC

### DIFF
--- a/api/src/lib/connector.js
+++ b/api/src/lib/connector.js
@@ -233,9 +233,7 @@ module.exports = class Conncetor {
     return promise
   }
 
-  * rpc(prefix, method, params) {
-    const plugin = connector.getPlugin(prefix)
-
-    return plugin.receive(method, params)
+  getPlugin (prefix) {
+    return getPlugin(prefix)
   }
 }


### PR DESCRIPTION
Return a 404 when the plugin with the given prefix isn't found, and return a 422 when the `receive` function on the plugin gives an error. The 404 message is printed with the `debug` log level, so that  you won't see unreciprocated peers by default.