### PR TITLE
Upgrade to webfinger.js version 2.6.1, fix #204

### DIFF
--- a/api/test/utils.test.js
+++ b/api/test/utils.test.js
@@ -121,6 +121,24 @@ describe('Utils', () => {
     })
   })
 
+  it('doesn\'t get a malformed webfinger record (bug #204)', function * () {
+    nock('https://mal.formed')
+      .get('/.well-known/webfinger?resource=acct:alice@mal.formed')
+      .reply(200, {
+        links: {
+          rel: 'https://interledger.org/rel/ledgerAccount',
+          href: 'account'
+        }
+      })
+    try {
+      yield this.utils.getWebfingerAccount(
+        'alice@mal.formed')
+      assert(false, 'this.util.getWebfingerAccount should have failed')
+    } catch (e) {
+      assert(nock.isDone(), 'nock should be called')
+    }
+  })
+
   it('gets a destination from non-foreign ID', function * () {
     nock('https://red.ilpdemo.org')
       .get('/ledger/accounts/alice')

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "umzug": "^1.11.0",
     "url-loader": "^0.5.6",
     "uuid4": "^1.0.0",
-    "webfinger.js": "^2.3.2",
+    "webfinger.js": "^2.6.1",
     "webpack": "^1.13.2",
     "webpack-isomorphic-tools": "^2.5.7"
   },


### PR DESCRIPTION
The cause of #204 was fixed upstream in webfinger.js; this PR updates the dependency and adds a unit test for the bug.