### PR TITLE
Upgrade to webfinger.js v2.6.2

### DIFF
--- a/api/src/lib/utils.js
+++ b/api/src/lib/utils.js
@@ -25,7 +25,7 @@ module.exports = class Utils {
     return destination.search('@') > -1
   }
 
-  * webfingerLookup (resource) {
+  * _webfingerLookup (resource) {
     const webfinger = new WebFinger({
       webfist_fallback: false,
       tls_only: true,
@@ -40,7 +40,7 @@ module.exports = class Utils {
 
   * getWebfingerAccount (address) {
     try {
-      const response = yield this.webfingerLookup(address)
+      const response = yield this._webfingerLookup(address)
 
       return {
         ledgerUri: _.filter(response.links, {rel: 'https://interledger.org/rel/ledgerUri'})[0].href,
@@ -106,7 +106,7 @@ module.exports = class Utils {
   * hostLookup (host) {
     let response
     try {
-      response = yield this.webfingerLookup(host)
+      response = yield this._webfingerLookup(host)
     } catch (e) {
       throw new NotFoundError('Host is unavailable')
     }
@@ -114,9 +114,13 @@ module.exports = class Utils {
     if (!response) throw new NotFoundError('Host is unavailable')
     if (!response.properties) throw new NotFoundError("Host doesn't have an ilp-kit or the version is not compatible")
 
-    return {
-      publicKey: response.properties['https://interledger.org/rel/publicKey'],
-      peersRpcUri: _.filter(response.links, {rel: 'https://interledger.org/rel/peersRpcUri'})[0].href
+    try {
+      return {
+        publicKey: response.properties['https://interledger.org/rel/publicKey'],
+        peersRpcUri: _.filter(response.links, {rel: 'https://interledger.org/rel/peersRpcUri'})[0].href
+      }
+    } catch (e) {
+      throw new NotFoundError('Host webfinger parsing failed')
     }
   }
 }

--- a/api/test/utils.test.js
+++ b/api/test/utils.test.js
@@ -7,6 +7,102 @@ const Utils = require('../src/lib/utils')
 const assert = require('chai').assert
 const nock = require('nock')
 
+function nockAcct() {
+  nock('https://example.com')
+    .get('/.well-known/webfinger?resource=acct:alice@example.com')
+    .reply(200, {
+      links: [{
+        rel: 'https://interledger.org/rel/ledgerAccount',
+        href: 'account'
+      }, {
+        rel: 'https://interledger.org/rel/ledgerUri',
+        href: 'ledger'
+      }, {
+        rel: 'https://interledger.org/rel/receiver',
+        href: 'http://receiver/'
+      }, {
+        rel: 'https://interledger.org/rel/ilpAddress',
+        href: 'address'
+      }]
+    })
+}
+
+function nockUri() {
+  nock('https://example.com')
+    .get('/.well-known/webfinger?resource=https://example.com/accounts/alice')
+    .reply(200, {
+      links: [{
+        rel: 'https://interledger.org/rel/ledgerAccount',
+        href: 'account'
+      }, {
+        rel: 'https://interledger.org/rel/ledgerUri',
+        href: 'ledger'
+      }, {
+        rel: 'https://interledger.org/rel/receiver',
+        href: 'http://receiver/'
+      }, {
+        rel: 'https://interledger.org/rel/ilpAddress',
+        href: 'address'
+      }]
+    })
+}
+
+
+function nockHost() {
+  nock('https://ilp-kit.somebody.com')
+    .get('/.well-known/webfinger?resource=https://ilp-kit.somebody.com')
+    .reply(200, {
+      properties: {
+        'https://interledger.org/rel/publicKey': 'some-pub-key'
+      },
+      links: [{
+        rel: 'https://interledger.org/rel/peersRpcUri',
+        href: 'peers-rpc-uri-href'
+      }]
+    })
+}
+
+function nockHostEmpty() {
+  nock('https://ilp-kit.somebody.com')
+    .get('/.well-known/webfinger?resource=https://ilp-kit.somebody.com')
+    .reply(200, {
+      properties: {},
+      links: []
+    })
+}
+
+
+function nockDestinationLocal() {
+  nock('https://localhost:80')
+    .get('/api/receivers/alice')
+    .reply(200, {
+      name: 'alice',
+      imageUrl: 'picture',
+      currency_code: 'XDG',
+      currency_symbol: 'D'
+    })
+}
+function nockDestinationRemote() {
+  nock('http://receiver')
+    .get('/')
+    .reply(200, {
+      name: 'alice',
+      imageUrl: 'picture',
+      currency_code: 'XDG',
+      currency_symbol: 'D'
+    })
+}
+function nockMalformed() {
+  nock('https://mal.formed')
+    .get('/.well-known/webfinger?resource=acct:alice@mal.formed')
+    .reply(200, {
+      links: {
+        rel: 'https://interledger.org/rel/ledgerAccount',
+        href: 'account'
+      }
+    })
+}
+
 describe('Utils', () => {
   beforeEach(function * () {
     const container = new constitute.Container()
@@ -15,55 +111,61 @@ describe('Utils', () => {
     this.utils = container.constitute(Utils)
   })
 
-  it('detects a webfinger identifier', function () {
-    assert.isTrue(this.utils.isWebfinger('alice@example.com'))
-    assert.isFalse(this.utils.isWebfinger('http://example'))
+  describe('isWebfinger', function() {
+    it('detects a webfinger identifier', function () {
+      assert.isTrue(this.utils.isWebfinger('alice@example.com'))
+      assert.isFalse(this.utils.isWebfinger('https://example.com'))
+      assert.isFalse(this.utils.isWebfinger('http://example'))
+      assert.isFalse(this.utils.isWebfinger('alice'))
+    })
   })
 
-  it.skip('doesn\'t get an account that doesn\'t exist', function * () {
-    try {
-      yield this.utils.getAccount('https://example.com/accounts/nonentity')
-      assert(false, 'this.util.getAccount should have failed')
-    } catch (e) {
-      assert(true)
-    }
+  describe('getWebfingerAccount', function() {
+    it('doesn\'t get an account that doesn\'t exist', function * () {
+      try {
+        yield this.utils.getWebfingerAccount('https://example.com/accounts/nonentity')
+        assert(false, 'this.util.getWebfingerAccount should have failed')
+      } catch (e) {
+        assert(true)
+      }
+    })
+
+    it('doesn\'t get a webfinger account that doesn\'t exist', function * () {
+      try {
+        yield this.utils.getWebfingerAccount(
+          'https://example.com/accounts/nonentity')
+        assert(false, 'this.util.getWebfingerAccount should have failed')
+      } catch (e) {
+        assert(true)
+      }
+    })
   })
 
-  it.skip('doesn\'t get a webfinger account that doesn\'t exist', function * () {
-    try {
-      yield this.utils.getWebfingerAccount(
-        'https://example.com/accounts/nonentity')
-      assert(false, 'this.util.getWebfingerAccount should have failed')
-    } catch (e) {
-      assert(true)
-    }
+  describe('getWebfingerAddress', function() {
+    // tested below in 'gets a webfinger account
+  })
+  describe('webfingerLookup', function() {
+    // called from getWebfingerAccount, so it's also
+    // tested below in 'gets a webfinger account'
   })
 
   describe('Webfinger', () => {
-    beforeEach(function () {
-      nock('https://example.com')
-        .get('/.well-known/webfinger?resource=acct:alice@example.com')
-        .reply(200, {
-          links: [{
-            rel: 'https://interledger.org/rel/ledgerAccount',
-            href: 'account'
-          }, {
-            rel: 'https://interledger.org/rel/ledgerUri',
-            href: 'ledger'
-          }, {
-            rel: 'https://interledger.org/rel/receiver',
-            href: 'http://receiver/'
-          }, {
-            rel: 'https://interledger.org/rel/ilpAddress',
-            href: 'address'
-          }]
-        })
+    beforeEach(function() {
+      this.destinationLocal = {
+        ledgerUri: 'https://red.ilpdemo.org/ledger',
+        paymentUri: 'https://localhost:80/api/receivers/alice',
+        ilpAddress: 'us.usd.red.alice',
+        currencyCode: 'XDG',
+        currencySymbol: 'D',
+        identifier: 'alice@localhost:80',
+        name: 'alice',
+        imageUrl: undefined
+      }
 
-      this.destination = {
-        type: 'local',
-        accountUri: 'account',
+      this.destinationRemote = {
         ledgerUri: 'ledger',
         paymentUri: 'http://receiver/',
+        identifier: 'alice@example.com',
         ilpAddress: 'address',
         currencyCode: 'XDG',
         currencySymbol: 'D',
@@ -72,10 +174,14 @@ describe('Utils', () => {
       }
 
       this.webfinger = {
-        accountUri: 'account',
         ledgerUri: 'ledger',
         paymentUri: 'http://receiver/',
         ilpAddress: 'address'
+      }
+
+      this.webfingerHost = {
+        peersRpcUri: 'peers-rpc-uri-href',
+        publicKey: 'some-pub-key'
       }
     })
 
@@ -83,85 +189,85 @@ describe('Utils', () => {
       assert(nock.isDone(), 'nock should be called')
     })
 
-    it.skip('gets a webfinger account with URI', function * () {
-      assert.deepEqual(yield this.utils.getWebfingerAccount(
+    it('gets a webfinger account with URI', function * () {
+      nockUri()
+      var result = yield this.utils.getWebfingerAccount(
         'https://example.com/accounts/alice'
-      ), this.webfinger)
+      )
+      assert.deepEqual(result, this.webfinger)
     })
 
-    it.skip('gets a webfinger account with ID', function * () {
+    it('gets a webfinger account with ID', function * () {
+      nockAcct()
       assert.deepEqual(yield this.utils.getWebfingerAccount(
         'alice@example.com'
       ), this.webfinger)
     })
 
     describe('parseDestination', () => {
-      beforeEach(function () {
-        nock('http://receiver')
-          .get('/')
-          .reply(200, {
-            name: 'alice',
-            imageUrl: 'picture',
-            currency_code: 'XDG',
-            currency_symbol: 'D'
-          })
+      beforeEach(function() {
       })
 
+      // SPSP addresses of the form https://example.com/accounts/alice
+      // is not currently supported, so skipping this test:
       it.skip('gets a destination from URI', function * () {
+        nockDestinationLocal()
+        nockUri()
         assert.deepEqual(yield this.utils.parseDestination({
           destination: 'https://example.com/accounts/alice'
-        }), this.destination)
+        }), this.destinationLocal)
       })
 
-      it.skip('gets a destination from Webfinger ID', function * () {
+      it('gets a destination from Webfinger ID', function * () {
+        nockAcct()
+        nockDestinationRemote()
         assert.deepEqual(yield this.utils.parseDestination({
           destination: 'alice@example.com'
-        }), this.destination)
+        }), this.destinationRemote)
       })
     })
-  })
 
-  it('doesn\'t get a malformed webfinger record (bug #204)', function * () {
-    nock('https://mal.formed')
-      .get('/.well-known/webfinger?resource=acct:alice@mal.formed')
-      .reply(200, {
-        links: {
-          rel: 'https://interledger.org/rel/ledgerAccount',
-          href: 'account'
+    it('doesn\'t get a malformed webfinger record (bug #204)', function * () {
+      try {
+        yield this.utils.getWebfingerAccount(
+          'alice@mal.formed')
+        assert(false, 'this.util.getWebfingerAccount should have failed')
+      } catch (e) {
+        assert(nock.isDone(), 'nock should be called')
+      }
+    })
+ 
+    it('gets a destination from non-foreign ID', function * () {
+      nockDestinationLocal()
+      assert.deepEqual(yield this.utils.parseDestination({
+        destination: 'alice'
+      }), this.destinationLocal)
+ 
+      assert(nock.isDone(), 'nock should be called')
+    })
+
+    describe('hostLookup', function() {
+      it('gets host data from webfinger', function * () {
+        nockHost()
+        assert.deepEqual(yield this.utils.hostLookup(
+          'https://ilp-kit.somebody.com'
+        ), this.webfingerHost)
+        assert(nock.isDone(), 'nock should be called')
+      })
+
+      it('doesn\'t get incompatible host data from webfinger', function * () {
+        nockHostEmpty()
+        try {
+          assert.deepEqual(yield this.utils.hostLookup(
+            'https://ilp-kit.somebody.com'
+          ), this.webfingerHost)
+          assert(false, 'this.util.hostLookup should have failed')
+        } catch (e) {
+          assert(nock.isDone(), 'nock should be called')
         }
       })
-    try {
-      yield this.utils.getWebfingerAccount(
-        'alice@mal.formed')
-      assert(false, 'this.util.getWebfingerAccount should have failed')
-    } catch (e) {
-      assert(nock.isDone(), 'nock should be called')
-    }
-  })
-
-  it('gets a destination from non-foreign ID', function * () {
-    nock('https://localhost:80')
-      .get('/api/receivers/alice')
-      .reply(200, {
-        name: 'alice',
-        imageUrl: 'picture',
-        currency_code: 'XDG',
-        currency_symbol: 'D'
-      })
-
-    assert.deepEqual(yield this.utils.parseDestination({
-      destination: 'alice'
-    }), {
-      ledgerUri: 'https://red.ilpdemo.org/ledger',
-      paymentUri: 'https://localhost:80/api/receivers/alice',
-      identifier: 'alice@localhost:80',
-      ilpAddress: 'us.usd.red.alice',
-      currencyCode: 'XDG',
-      currencySymbol: 'D',
-      name: 'alice',
-      imageUrl: undefined
     })
 
-    assert(nock.isDone(), 'nock should be called')
   })
+
 })

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "umzug": "^1.11.0",
     "url-loader": "^0.5.6",
     "uuid4": "^1.0.0",
-    "webfinger.js": "^2.6.1",
+    "webfinger.js": "^2.6.2",
     "webpack": "^1.13.2",
     "webpack-isomorphic-tools": "^2.5.7"
   },


### PR DESCRIPTION
This allows us to reenable a number of tests for `api/src/utils.js`