### PR TITLE
Use pm2

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -212,7 +212,10 @@ The CLI provides example values, but I'll also put the configuration I'm using.
 **That's all you need for a functioning ILP Kit!** To start your ILP Kit, run:
 
 ```sh
-$ npm start
+$ npm install -g pm2
+$ pm2 start pm2.config.js
+$ pm2 list # you should see three apps running: ledger, api, and web.
+$ pm2 logs
 ```
 
 Your connector's account will be automatically created and given $1000, so you can
@@ -406,46 +409,9 @@ funds in this way. You don't want to owe more to other accounts than you can
 pay back, nor do you want people to be able to send massive payments through
 your connector.
 
-## systemd setup
+## Restarting ilp-kit after a server reboot
 
-Create the service file
-```
-sudo vi /etc/systemd/system/ilp-kit.service
-```
-
-with the contents
-```
-[Service]
-ExecStart=/usr/bin/npm start
-Restart=always
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=ilp-kit
-User=root
-Group=root
-WorkingDirectory=/var/ilp-kit
-
-[Install]
-WantedBy=multi-user.target
-```
-where `WorkingDirectory` is the path to your `ilp-kit` folder.
-
-Restart the daemon
-```
-sudo systemctl daemon-reload
-```
-
-Start the service
-```
-sudo systemctl start ilp-kit
-```
-
-Make it start on reboot
-```
-sudo systemctl enable ilp-kit
-```
-
-You can check the logs with this command
-```
-journalctl -u ilp-kit -f -n 500
-```
+One easy way to make sure your ilp-kit is started again after a reboot, is
+running `pm2 startup`, and then following the instructions of what you have
+to run as root. So type `exit` and run the recommended command as root.
+You can restart your server after this, and check that it worked.

--- a/pm2.config.js
+++ b/pm2.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+  /**
+   * Application configuration section
+   * http://pm2.keymetrics.io/docs/usage/application-declaration/
+   */
+  apps : [
+    {
+      name      : 'ledger',
+      script    : './bin/ledger.js',
+      env: {
+        COMMON_VARIABLE: 'true',
+        NODE_PATH: './src',
+        NODE_ENV: 'production'
+      }
+    },
+    {
+      name      : 'api',
+      script    : './bin/api.js',
+      env: {
+        COMMON_VARIABLE: 'true',
+        NODE_PATH: './api',
+        NODE_ENV: 'production'
+      }
+    },
+    {
+      name      : 'web',
+      script    : './bin/server.js',
+      env: {
+        COMMON_VARIABLE: 'true',
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+};


### PR DESCRIPTION
There are three process that are started up by `npm start`.
To make sure each of them is restarted after a crash, and
to deal with logs in a better way, it's better to run them
through a process manager than directly in a screen.

Also, now that the processes run under pm2, we might as well use pm2 to boot them up, it's a
simplification of the docs, and systemd enthusiast can still choose to use it anyway.