### PR TITLE
Fix `npm run test-api` in 2.0 branch

### DIFF
--- a/api/test/utils.test.js
+++ b/api/test/utils.test.js
@@ -18,7 +18,7 @@ function nockAcct() {
         rel: 'https://interledger.org/rel/ledgerUri',
         href: 'ledger'
       }, {
-        rel: 'https://interledger.org/rel/receiver',
+        rel: 'https://interledger.org/rel/spsp/v2',
         href: 'http://receiver/'
       }, {
         rel: 'https://interledger.org/rel/ilpAddress',
@@ -38,7 +38,7 @@ function nockUri() {
         rel: 'https://interledger.org/rel/ledgerUri',
         href: 'ledger'
       }, {
-        rel: 'https://interledger.org/rel/receiver',
+        rel: 'https://interledger.org/rel/spsp/v2',
         href: 'http://receiver/'
       }, {
         rel: 'https://interledger.org/rel/ilpAddress',


### PR DESCRIPTION
You updated the webfinger behavior, but not the fixture for it in the api tests. This patch adds the corresponding fixture change.