### PR TITLE
build: Align pushed Docker tag with the one that was created

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ deployment:
       # Push Docker image tagged latest and tagged with commit descriptor
       - sed "s/<AUTH>/${DOCKER_TOKEN}/" < "dockercfg-template" > ~/.dockercfg
       - docker push interledgerjs/ilp-kit:latest
-      - docker push interledgerjs/ilp-kit:"$(git describe)"
+      - docker push interledgerjs/ilp-kit:"$(git describe --tags)"
       # Publish spec
       - git config --global user.email "info@circleci.com"
       - git config --global user.name "CircleCI"


### PR DESCRIPTION
It was creating a Docker tag based on `git describe --tags` and then trying to push the one based on `git describe`. That is sometimes the same but not always, so safer to use the `git describe --tags` in both cases. This will hopefully make master green again.