### PR TITLE
Tag v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.2.1
+
+* More complete documentation and usage instructions
+* Several security fixes
+* Improvements in the withdrawal (peer settlement) functionality
+
 # v1.2.0
 
 * Activity Logs were introduced

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,29 @@
+# Upgrading your ilp-kit
+
+Assuming you run ilp-kit through pm2, first take it offline:
+```sh
+pm2 stop server
+pm2 stop api
+pm2 stop ledger
+```
+
+Now update the code:
+```sh
+rm -rf node_modules
+npm install
+npm run build
+```
+
+And start it back up:
+```sh
+pm2 start ledger
+pm2 start api
+pm2 start server
+```
+
+
+
+To check that the server is running again, open `https://<your-ilp-kit.com>/api/health`
+with your browser, and check that it says 'OK'.
+
+If it doesn't, try running `pm2 restart api`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilp-kit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ILP kit",
   "main": "bin/server.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
I manually tested this version on ilp-kit.michielbdejong.com, and found it works, at least on my machine: I was able to send money to Dennis's, Ivan's, and John's ilp-kits, all of which run v1.2.0 according to https://connector.land.

I couldn't send money to Ben's or Evan's ilp-kit, but they are both on v1.1.0, so maybe they also haven't been restarted for a long time?

@sharafian @emschwartz it would be interesting to see if I can send to your ilp-kits after you restart them.

This PR also includes upgrade instructions, especially the hint to check `/api/health` and restart the api process if necessary, which helps avoid the "Cannot access object.githubAuth of null" errors on the login page.