### PR TITLE
Feat: BREAKING take authorization for RPC requests

### DIFF
--- a/api/src/lib/config.js
+++ b/api/src/lib/config.js
@@ -3,7 +3,7 @@
 const Config = require('five-bells-shared').Config
 const envPrefix = 'api'
 const crypto = require('crypto')
-const getPublicKey = require('ilp-plugin-virtual/src/util/token').publicKey
+const generatePublicKey = require('ilp-plugin-virtual').generatePublicKey
 const changeAdminPass = require('../../../bin/env').changeAdminPass
 
 module.exports = class WalletConfig {
@@ -71,7 +71,7 @@ module.exports = class WalletConfig {
     localConfig.connector = {
       ed25519_secret_key: Config.getEnv('CONNECTOR_ED25519_SECRET_KEY'),
       ledgers: Config.getEnv('CONNECTOR_LEDGERS'),
-      public_key: getPublicKey(Config.getEnv('CONNECTOR_ED25519_SECRET_KEY'))
+      public_key: generatePublicKey(Config.getEnv('CONNECTOR_ED25519_SECRET_KEY'))
     }
 
     localConfig.reload = Config.getEnv(envPrefix, 'RELOAD')

--- a/api/src/lib/connector.js
+++ b/api/src/lib/connector.js
@@ -8,7 +8,7 @@ const Config = require('./config')
 const Utils = require('./utils')
 const PeerFactory = require('../models/peer')
 const SettlementMethodFactory = require('../models/settlement_method')
-const getPrefix = require('ilp-plugin-virtual/src/util/token').prefix
+const { generatePrefix } = require('ilp-plugin-virtual')
 
 const InvalidBodyError = require('../errors/invalid-body-error')
 
@@ -87,7 +87,7 @@ module.exports = class Conncetor {
 
       //this calls the function in ilp-plugin-virtual src/utils/token.js, which looks like:
       //const prefix = ({ secretKey, peerPublicKey, currencyScale, currencyCode }) => {
-      ledgerName = getPrefix({
+      ledgerName = generatePrefix({
         secretKey: this.config.data.getIn(['connector', 'ed25519_secret_key']),
         peerPublicKey: publicKey,
         currencyScale: peer.currencyScale || 9,

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "ilp-kit-cli": "^11.1.0",
     "ilp-plugin-bells": "^13.0.0",
     "ilp-plugin-settlement-adapter": "^1.0.0",
-    "ilp-plugin-virtual": "git://github.com/interledgerjs/ilp-plugin-virtual",
+    "ilp-plugin-virtual": "git://github.com/interledgerjs/ilp-plugin-virtual#bs-auth-virtual",
     "ilp-routing": "git://github.com/interledgerjs/ilp-routing#ded680a",
     "istanbul": "^0.4.5",
     "jimp": "^0.2.27",


### PR DESCRIPTION
Uses `.authorize` on plugin virtual to authenticate RPC requests. The plugin uses a symmetric token (an HMAC of the shared secret) to authenticate RPC requests. Depends on https://github.com/interledgerjs/ilp-plugin-virtual/pull/58