### PR TITLE
Fix spsp test fixtures

### DIFF
--- a/api/src/lib/utils.js
+++ b/api/src/lib/utils.js
@@ -66,6 +66,7 @@ module.exports = class Utils {
     let paymentUri
     let ilpAddress
     let ledgerInfo = {}
+    let receiverInfo = {}
 
     if (self.isWebfinger(destination)) {
       // Webfinger lookup
@@ -82,12 +83,14 @@ module.exports = class Utils {
     }
 
     // Get SPSP receiver info
-    let receiver
+    let spspResponse
     try {
-      receiver = (yield superagent.get(paymentUri).end()).body
-      ledgerInfo = receiver.ledger_info
+      spspResponse = (yield superagent.get(paymentUri).end()).body
+
+      ledgerInfo = spspResponse.ledger_info
+      receiverInfo = spspResponse.receiver_info
     } catch (e) {
-      throw new NotFoundError('Unknown receiver')
+      throw new NotFoundError('Unknown spsp receiver')
     }
 
     return {
@@ -97,8 +100,8 @@ module.exports = class Utils {
       identifier: self.isWebfinger(destination) ? destination : this.getWebfingerAddress(destination),
       currencyCode: ledgerInfo.currency_code,
       currencySymbol: currencySymbolMap[ledgerInfo.currency_code],
-      name: receiver.name,
-      imageUrl: receiver.image_url
+      name: receiverInfo.name,
+      imageUrl: receiverInfo.image_url
     }
   }
 

--- a/api/test/utils.test.js
+++ b/api/test/utils.test.js
@@ -71,26 +71,34 @@ function nockHostEmpty() {
     })
 }
 
+function spspResponse(currencyCode) {
+  return {
+    destination_account: 'example.ilpdemo.red.alice',
+    shared_secret: '6jR5iNIVRvqeasJeCty6C-YB5X9FhSOUPCL_5nha5Vs',
+    maximum_destination_amount: '18000000000000000000',
+                               //12345678901234567890
+    minimum_destination_amount: '1',
+    ledger_info: {
+      currency_code: currencyCode,
+      currency_scale: 9,
+      precision: 19
+    },
+    receiver_info: {
+      name: 'Alice in Wonderland',
+      image_url: 'https://red.ilpdemo.org/api/spsp/alic/profile_pic.jpg'
+    }
+  }
+}
 
 function nockDestinationLocal() {
   nock('https://localhost:80')
     .get('/api/spsp/alice')
-    .reply(200, {
-      name: 'alice',
-      imageUrl: 'picture',
-      currency_code: 'XDG',
-      currency_scale: 3
-    })
+    .reply(200, spspResponse('JPY'))
 }
 function nockDestinationRemote() {
   nock('http://receiver')
     .get('/')
-    .reply(200, {
-      name: 'alice',
-      imageUrl: 'picture',
-      currency_code: 'XDG',
-      currency_scale: 3
-    })
+    .reply(200, spspResponse('XDG'))
 }
 function nockMalformed() {
   nock('https://mal.formed')
@@ -155,11 +163,11 @@ describe('Utils', () => {
         ledgerUri: 'https://red.ilpdemo.org/ledger',
         paymentUri: 'https://localhost:80/api/spsp/alice',
         ilpAddress: 'us.usd.red.alice',
-        currencyCode: 'XDG',
-        currencyScale: 3,
+        currencyCode: 'JPY',
+        currencySymbol: '¥',
         identifier: 'alice@localhost:80',
-        name: 'alice',
-        imageUrl: undefined
+        name: 'Alice in Wonderland',
+        imageUrl: 'https://red.ilpdemo.org/api/spsp/alic/profile_pic.jpg'
       }
 
       this.destinationRemote = {
@@ -168,9 +176,9 @@ describe('Utils', () => {
         identifier: 'alice@example.com',
         ilpAddress: 'address',
         currencyCode: 'XDG',
-        currencyScale: 3,
-        name: 'alice',
-        imageUrl: undefined
+        currencySymbol: undefined,
+        name: 'Alice in Wonderland',
+        imageUrl: 'https://red.ilpdemo.org/api/spsp/alic/profile_pic.jpg'
       }
 
       this.webfinger = {
@@ -218,7 +226,7 @@ describe('Utils', () => {
         }), this.destinationLocal)
       })
 
-      it.skip('gets a destination from Webfinger ID', function * () {
+      it('gets a destination from Webfinger ID', function * () {
         nockAcct()
         nockDestinationRemote()
         assert.deepEqual(yield this.utils.parseDestination({
@@ -237,7 +245,7 @@ describe('Utils', () => {
       }
     })
 
-    it.skip('gets a destination from non-foreign ID', function * () {
+    it('gets a destination from non-foreign ID', function * () {
       nockDestinationLocal()
       assert.deepEqual(yield this.utils.parseDestination({
         destination: 'alice'


### PR DESCRIPTION
This uses fixtures from the spsp spec, and checks that the api call returns an appropriate currencySymbol for a well-known currency.