### PR TITLE
Fix: Dockerfile, local webfinger calls, and profile picture cropping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM node:6-slim
+FROM node:7-slim
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY . /usr/src/app
 
-EXPOSE 3000
+# native modules need to be rebuilt for the new system
+RUN apt-get update && apt-get install -y python postgresql libpq-dev build-essential
+RUN npm rebuild
+
+EXPOSE 3010
 
 CMD [ "npm", "start" ]

--- a/api/src/controllers/auth.js
+++ b/api/src/controllers/auth.js
@@ -194,7 +194,7 @@ function AuthControllerFactory (User, log, ledger, mailer, auth) {
 
       user = yield User.findOne({where: {id: user.id}})
 
-      const newFilePath = file.path.replace(/(\.[\w\d_-]+)$/i, '_square$1')
+      const newFilePath = file.path + '_square.' + file.type.split('/')[1]
 
       // Resize
       try {
@@ -203,7 +203,7 @@ function AuthControllerFactory (User, log, ledger, mailer, auth) {
         image.cover(200, 200, jimp.HORIZONTAL_ALIGN_CENTER, jimp.VERTICAL_ALIGN_TOP)
           .write(newFilePath, err => {
             if (err) {
-              console.log('auth:197', err)
+              console.log('auth:197', newFilePath, err)
             }
           })
       } catch (e) {

--- a/api/src/lib/spsp.js
+++ b/api/src/lib/spsp.js
@@ -62,10 +62,15 @@ module.exports = class SPSP {
   // .sourceAmount XOR .destinationAmount
   * quote (params) {
     yield this.factory.connect()
+
+    // save a webfinger call if it's on the same domain
+    const receiver = this.utils.resolveSpspIdentifier(params.destination)
+    debug('making SPSP quote to', receiver)
+
     return ILP.SPSP.quote(
       yield this.factory.create({ username: params.user.username }),
       {
-        receiver: params.destination,
+        receiver,
         sourceAmount: params.sourceAmount,
         destinationAmount: params.destinationAmount
       }

--- a/api/src/lib/utils.js
+++ b/api/src/lib/utils.js
@@ -22,6 +22,12 @@ module.exports = class Utils {
     this.localHost = config.data.getIn(['server', 'base_host'])
   }
 
+  resolveSpspIdentifier (identifier) {
+    const [ username, domain ] = identifier.split('@')
+    if (domain !== this.localHost) return identifier
+    return this.localUri + '/spsp/' + username
+  }
+
   isWebfinger (destination) {
     // TODO better email style checking
     return destination.search('@') > -1

--- a/src/containers/Settings/ProfileForm.js
+++ b/src/containers/Settings/ProfileForm.js
@@ -88,6 +88,7 @@ export default class ProfileForm extends Component {
   dropzoneConfig = {
     showFiletypeIcon: false,
     postUrl: '/api/auth/profilepic',
+    iconFiletypes: [ '.jpg', '.png', '.jpeg', '.gif' ],
     maxFiles: 1
   }
 


### PR DESCRIPTION
1. The dockerfile wasn't rebuilding dependencies, so if you ran `docker build` on a system that didn't match the one in `node:7-slim` it would fail to load any native modules. (Unfortunately this means the docker image needs build tools inside)

2. The webfinger call is taken out for local transfers, because we already know our own SPSP endpoint. This makes loading a little quicker, and also means that we don't need HTTPS so long as we're just sending within our own ILP Kit (so long as HTTPS was disabled on the ILP kit).

3. The profile picture code broke at some point, so this fixes it by using the correct file extension for the cropped output file