### PR TITLE
Fix: add libpq5 to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 # native modules need to be rebuilt for the new system
-RUN apt-get update && apt-get install -y python postgresql libpq-dev build-essential
+RUN apt-get update && apt-get install -y python postgresql libpq-dev build-essential libpq5
 RUN npm rebuild
 
 EXPOSE 3010


### PR DESCRIPTION
Missing libpq causes ILP Kit to crash when being run from the docker image. Whoever approves can merge this PR.