### PR TITLE
Feat: fallback to source identifier if user has no name

### DIFF
--- a/api/src/lib/pay.js
+++ b/api/src/lib/pay.js
@@ -26,7 +26,7 @@ module.exports = class Pay {
         opts.user.username,
         Object.assign({}, opts.quote, { headers: {
           'Source-Identifier': opts.user.identifier,
-          'Source-Name': opts.user.name,
+          'Source-Name': opts.user.name || opts.user.identifier,
           'Source-Image-Url': this.utils.userToImageUrl(opts.user),
           'Message': opts.message || ''
         }}))


### PR DESCRIPTION
If the user hasn't set a name, then their identifier (eg. `user@host.example`) should be used instead. Closes https://github.com/interledgerjs/ilp-kit/issues/342