### PR TITLE
Scan system to check if Postgres version is up to date

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "test-mocha": "NODE_ENV=test ./node_modules/.bin/mocha api/test",
     "integration": "integration-loader && integration all",
     "apidoc": "apidoc -i api/src/controllers/ -o apidoc-out",
-    "configure": "./node_modules/ilp-kit-cli/bin/configure.js"
+    "version-check" : "echo 'Scanning psql version'; chmod +x ./scripts/postgres_version_check.sh; if [ $(bash ./scripts/postgres_version_check.sh) = 'false' ]; then echo 'Postgres PSQL Version out of date, please upgrade to 9.5 or newer'; exit 126; fi;",
+    "configure": "npm run version-check && ./node_modules/ilp-kit-cli/bin/configure.js"
   },
   "betterScripts": {
     "start-prod": {

--- a/scripts/postgres_version_check.sh
+++ b/scripts/postgres_version_check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+psql_version=$(psql --version)
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+current_version=${psql_version//[^[:digit:].-]/}
+min_version=9.4.9
+if version_gt $current_version $min_version; then
+  echo 'true'
+else 
+  echo 'false'
+fi


### PR DESCRIPTION
Adds error throw logic during `npm run configure` if psql version is behind v9.5.

Solves issue #311.