### PR TITLE
build: Changes from where dependency koa-socket-2 is loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "koa-passport": "^3.0.0",
     "koa-router": "^7.2.0",
     "koa-session": "^5.0.0",
-    "koa-socket-2": "git://github.com/ambelovsky/koa-socket-2.git#0206fbb00679a1b8517031c654141bde474dda57",
+    "koa-socket-2": "^1.0.8",
     "koa-static": "^3.0.0",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",


### PR DESCRIPTION
Loads the published version of koa-socket-2 instead of a specific github commit.