### PR TITLE
fix: ensure connector ready before start() returns

### DIFF
--- a/api/src/lib/app.js
+++ b/api/src/lib/app.js
@@ -96,7 +96,7 @@ module.exports = class App {
     const adminAccount = await this.user.setupAdminAccount()
     const connectorAccount = await this.user.setupConnectorAccount()
 
-    this.listen()
+    this.app.listen(this.config.data.getIn(['server', 'port']))
 
     await this.connector.start()
 
@@ -116,10 +116,6 @@ module.exports = class App {
         message: 'Initial connector funding'
       })
     }
-  }
-
-  listen () {
-    this.app.listen(this.config.data.getIn(['server', 'port']))
     this.log.info('wallet listening on ' + this.config.data.getIn(['server', 'bind_ip']) +
       ':' + this.config.data.getIn(['server', 'port']))
     this.log.info('public at ' + this.config.data.getIn(['server', 'base_uri']))

--- a/api/src/lib/connector.js
+++ b/api/src/lib/connector.js
@@ -33,7 +33,7 @@ module.exports = class Connector {
 
     this.log.info('Starting the connector...')
 
-    connector.listen()
+    await connector.listen()
 
     // Get the peers from the database
     const peers = await self.Peer.findAll()

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "hoist-non-react-statics": "^1.0.3",
     "http-proxy": "^1.12.0",
     "ilp": "^11.2.0",
-    "ilp-connector": "^21.1.4",
+    "ilp-connector": "^21.1.7",
     "ilp-kit-cli": "^11.4.1",
     "ilp-plugin-bells": "^15.0.0",
     "ilp-plugin-settlement-adapter": "https://github.com/interledgerjs/ilp-plugin-settlement-adapter.git",


### PR DESCRIPTION
* Fixes https://github.com/interledgerjs/ilp-kit/issues/430
* Fixes intermittent five-bells-integration-test failures.
* Requires [ilp-connector@21.1.6](https://github.com/interledgerjs/ilp-connector/issues/356).

Right now `connector.listen()` won't return until all ledgers are connected (see [ilp-connector/app.js](https://github.com/interledgerjs/ilp-connector/blob/0c5fad9a3b0317bbd3bdb04aef13f978d1ff9b96/src/app.js#L50-L51)), which could cause delays starting ilp-kit as well. Should it just return after the first attempt, and handle the retries in the background?