### PR TITLE
feat: add websocket RPC to API

### DIFF
--- a/api/src/controllers/websocket_rpc.js
+++ b/api/src/controllers/websocket_rpc.js
@@ -1,0 +1,55 @@
+'use strict'
+
+module.exports = WebsocketRpcControllerFactory
+
+const ws = require('ws')
+const debug = require('debug')('ilp-kit:websocket-rpc')
+const Connector = require('../lib/connector')
+
+function WebsocketRpcControllerFactory (deps) {
+  const connector = deps(Connector)
+
+  return class WebsocketRpcController {
+    static init (server) {
+     const socketServer = new ws.Server({
+        perMessageDeflate: false,
+        server
+      })
+
+      debug('listening for websocket connections')
+      socketServer.on('connection', socket => {
+        const url = socket.upgradeReq.url
+        const params = url.match(/^\/api\/peers\/rpc\/ws\/(.+?)\/(.+?)\/?$/)
+        if (!params) {
+          debug('Error: no ws at "' + url + '"')
+          socket.close()
+          return
+        }
+
+        const [ , prefix, token ] = params
+        let plugin
+
+        try {
+          plugin = connector.getPlugin(prefix)
+        } catch (e) {
+          debug(e)
+          socket.close()
+          return
+        }
+
+        if (!plugin || !plugin.isAuthorized(token)) {
+          debug(`Error: prefix (${prefix}) and/or token (${token}) are incorrect`)
+          socket.close()
+          return
+        }
+        
+        if (typeof plugin.addSocket === 'function') {
+          plugin.addSocket(socket)
+        } else {
+          debug(`Error: plugin ${prefix} does not support websocket RPC`)
+          socket.close()
+        }
+      })
+    }
+  }
+}

--- a/api/src/lib/app.js
+++ b/api/src/lib/app.js
@@ -20,6 +20,7 @@ const User = require('../models/user')
 const Socket = require('./socket')
 const Pay = require('./pay')
 const Connector = require('./connector')
+const WebsocketRpcController = require('../controllers/websocket_rpc')
 
 module.exports = class App {
   constructor (deps) {
@@ -36,6 +37,7 @@ module.exports = class App {
     const log = deps(Log)
     this.log = log('app')
     this.connector = deps(Connector)
+    this.websocketRpc = deps(WebsocketRpcController)
 
     this.validator.loadSchemasFromDirectory(path.resolve(__dirname, '../../schemas'))
 
@@ -121,7 +123,9 @@ module.exports = class App {
   }
 
   listen () {
-    this.app.listen(this.config.data.getIn(['server', 'port']))
+    const server = this.app.listen(this.config.data.getIn(['server', 'port']))
+    this.websocketRpc.init(server)
+
     this.log.info('wallet listening on ' + this.config.data.getIn(['server', 'bind_ip']) +
       ':' + this.config.data.getIn(['server', 'port']))
     this.log.info('public at ' + this.config.data.getIn(['server', 'base_uri']))


### PR DESCRIPTION
adds a websocket RPC endpoint to the ILP Kit API, which handles websocket connections and passes them off to the appropriate plugin. Authentication is done as outlined in https://github.com/interledger/interledger/wiki/Interledger-over-CLP

TODOs:

- better error handling for websocket connection errors
- proxy websockets so that they're accessible through the main port